### PR TITLE
deprecate nodejs <8.17, npm<6

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -75,8 +75,8 @@ After build staging it is the `lib` folder which actually gets published to NPM.
 ## NPM/Node Version Requirements
 
 `ethjs` requires you have:
-  - `nodejs` -v 6.5.0+
-  - `npm` -v 3.0+
+  - `nodejs` -v 8.17.0+
+  - `npm` -v 6.0+
 
 This is a requirement to run, test, lint and build this module.
 

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "web3"
   ],
   "engines": {
-    "npm": ">=3",
-    "node": ">=6.5.0"
+    "npm": ">=6",
+    "node": ">=8.17.0"
   },
   "author": "Nick Dodson <nick.dodson@consensys.net>",
   "license": "MIT",


### PR DESCRIPTION
nodejs boron (v6) entered maintenance on 2016-10-18 and EOL since 2019-04-30. It is not considered in active use anymore.